### PR TITLE
build: docker image from tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build image and push to ECR
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  AWS_REGION: eu-north-1
+  ECR_REPOSITORY: easyvmaf-s3
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - uses: mr-smithers-excellent/docker-build-push@v5
+        with:
+          image: ${{ env.ECR_REPOSITORY }}
+          registry: ${{ steps.login-ecr.outputs.registry }}
+          dockerfile: Dockerfile
+          addLatest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eyevinntechnology/easyvmaf:latest
 RUN pip3 install boto3
-WORKDIR  /app/easyVmaf-${easyVmaf_version}
+WORKDIR  /app/easyVmaf
 COPY easyvmaf_s3.py easyvmaf_s3.py
 ENTRYPOINT [ "python3", "easyvmaf_s3.py" ]
 


### PR DESCRIPTION
This will add a GH-action to build a docker image and push it to ECR, when creating a new tag.

Fixes #1